### PR TITLE
Update SEQ1.htm

### DIFF
--- a/Cours/SEQ1.htm
+++ b/Cours/SEQ1.htm
@@ -60,7 +60,7 @@
 <a href="../index.htm" target="_blank">Page d'accueil</a>
 <a href="./SEQ1.htm" target="_blank">Séquence 1</a>
 <a href="./SEQ2.htm" target="_blank">Séquence 2 - Les <i>Essais</i>, de Montaigne</a>
-<a href="./QCM" target="_blank">QCM</a>
+<a href="./QCM.htm" target="_blank">QCM</a>
   </nav>
 
 <article  id="formulaire">


### PR DESCRIPTION
le lien vers le QCM est mort car il manquait l'extension .htm dans le href du lien du menu qui va vers le qcm